### PR TITLE
Gradle 4.0+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 task uberjar(type: Jar,dependsOn:[':compileJava',':compileGroovy']) {
-    from files(sourceSets.main.output.classesDir)
+    from files(sourceSets.main.java.outputDir, sourceSets.main.groovy.outputDir)
     from configurations.runtime.asFileTree.files.collect { zipTree(it) }
 
     manifest {


### PR DESCRIPTION
Hello,

for Gradle 4.0+ it's required to use the specific source sets.

