### PR TITLE
Update uberjar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 	compile 'org.codehaus.gpars:gpars:0.12'
 }
 
-task uberjar(type: Jar,dependsOn:[':compileJava',':compileGroovy']) {
+task uberjar(type: Jar, dependsOn:compileGroovy) {
     from files(sourceSets.main.output.classesDir)
     from configurations.runtime.asFileTree.files.collect { zipTree(it) }
 


### PR DESCRIPTION
The only task which uberjar depends on is compileGroovy, so no need to include compileJava explicitly.